### PR TITLE
Abort a failed merge, to allow testing to continue.

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -34,7 +34,14 @@ merge() {
   export GIT_COMMITTER_EMAIL="foo@bar"
   export GIT_AUTHOR_NAME="github-merged-pr-buildkite-plugin"
   export GIT_COMMITTER_NAME="github-merged-pr-buildkite-plugin"
-  git merge "${BUILDKITE_COMMIT}"
+  if ! git merge "${BUILDKITE_COMMIT}"; then
+      # if the merge failed (due to conflicts), this script should
+      # still succeed, and testing should still continue (on the
+      # original code): it's useful to know whether that code compiles
+      # in isolation, and there will still be another set of testing
+      # done on the real merge, once the conflicts are resolved.
+      git merge --abort
+  fi
 }
 
 force_merge="${GITHUB_MERGED_PR_FORCE_BRANCH:-}"


### PR DESCRIPTION
Previously, if the merge failed, this merge script would fail, and the
whole build would fail without doing any useful testing. By aborting
the merge, testing can at least continue on the unmerged changes,
testing the branch in isolation.

NB. later, after the merge conflicts are resolved, testing will run
again and do the testing of the merge commit, so this doesn't weaken
guarantees of the testing of the final product.