### PR TITLE
Return to the commit of interest, when a merge fails.

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -veuo pipefail
 
 trigger() {
   local pr="$1"
@@ -41,6 +41,7 @@ merge() {
       # in isolation, and there will still be another set of testing
       # done on the real merge, once the conflicts are resolved.
       git merge --abort
+      git checkout "${BUILDKITE_COMMIT}"
   fi
 }
 


### PR DESCRIPTION
As it is, if there's merge conflicts, the build will continue running
on the FETCH_HEAD (i.e. HEAD of the target branch of the pull request,
in the target repo), rather than the PR's code.