### PR TITLE
Use bash's -x, not -v.

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -veuo pipefail
+set -xeuo pipefail
 
 trigger() {
   local pr="$1"


### PR DESCRIPTION
The -x (xtrace) setting will print each command (the exact command:
including the substitution of environment variables) as it is
executed, whereas -v prints each line as it is parsed. The former is
more useful for understanding what is happening during a script
execution.