### PR TITLE
Avoid making buildkite sections by accidental `+++`s from `set -x`

### DIFF
--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# buildkite treats lines starting with +++ (or ---) specially, and the
+# tracing here can result in that, so let's switch to * to avoid that
+export PS4=$(echo "$PS4" | sed 's/+/*/g')
 set -xeuo pipefail
 
 trigger() {


### PR DESCRIPTION
Buildkite logs treat lines with `+++` and `---` as creating sections,
and `set -x`s in nested shells (I think) can result in that with the
default setting of a prefix character (the first shell has `+ `, the
next has `++ `, and finally a third has `+++ `!). By switching to `*`
we avoid that: `*** ` doesn't mean anything to buildkite.

For example, see
https://buildkite.com/stellar/stellar-platform/builds/1448#f4d09876-4f0a-4153-b7be-be6ee1707ea2,
the following lines are just from the `set -x` emitting a `+++`, and
it'd be much nicer if the whole plugin invocation ("Running plugin
github-merged-pr post-checkout hook") was collapsed as it should be:

```
force_merge=	0s
[[ -n '' ]]	0s
pull_request=false	0s
[[ false == \f\a\l\s\e ]]	0s
echo 'Not a pull request, skipping'	0s
Not a pull request, skipping
exit 0
```